### PR TITLE
Fix screen freeze due to cross-thread access when plugins are compiled

### DIFF
--- a/KeeTheme/KeeThemeExt.cs
+++ b/KeeTheme/KeeThemeExt.cs
@@ -127,9 +127,16 @@ namespace KeeTheme
 
 		private void InitializeTheme()
 		{
+			if (_initialized) return; //Not required to fix issue #137
 			_theme.Enabled = _options.Enabled;
 			if (_theme.Enabled)
-				ApplyThemeInOpenForms();
+			{
+				if (Program.MainForm.InvokeRequired || KeePassLib.Utility.MonoWorkarounds.IsRequired(373134))
+				{
+					Program.MainForm.BeginInvoke(new Action(() => { ApplyThemeInOpenForms(); }));
+				}
+				else ApplyThemeInOpenForms();
+			}
 
 			_options.EnabledChanged += enable =>
 			{


### PR DESCRIPTION
Compiling plugins create a status dialog in an own thread and accessing the MainForm's handle is not possible in that case. BeginInvoke must be used because of lock(m_objSync) in OnDemandStatusDialog

Close #137 